### PR TITLE
Fixed situation where missing hint causes crash

### DIFF
--- a/livetable/lessEffortCallback.py
+++ b/livetable/lessEffortCallback.py
@@ -126,7 +126,12 @@ class LessEffortCallback(CallbackBase):
         # for each dimension, choose one field only
         # the plan can supply a list of fields. It's assumed the first
         # of the list is always the one plotted against
-        self.dim_fields = [fields[0] for fields, stream_name in dimensions]
+        self.dim_fields = []
+        for fields, stream_name in dimensions:
+            try:
+                self.dim_fields.append(fields[0])
+            except:
+                continue
 
         # make distinction between flattened fields and plotted fields
         # motivation for this is that when plotting, we find dependent variable


### PR DESCRIPTION
Unhinted motors were not being handled well by our less effort callback -- now if there is no hint for a motor, the "time" axis is used.